### PR TITLE
Fix hack/Makefile

### DIFF
--- a/hack/Makefile
+++ b/hack/Makefile
@@ -5,13 +5,14 @@ brew:
 	@$(BREW) cask reinstall multipass
 .PHONY: brew
 
-export define install_hack
+define install_hack
 if file ${hyperkit} | grep -q 'Mach-O.*executable'; then
 	mv ${hyperkit} ${hyperkit}.original
 	cp hyperkit.sh ${hyperkit}
 	chmod +x ${hyperkit}
 fi
 endef
+export install_hack
 
 hack: acquire-sudo
 	@sudo bash -c "eval \"$$install_hack\""


### PR DESCRIPTION
For some reasons, export define variable_name does not work with GNU make 3.81:
Makefile:9: *** missing separator.  Stop.

Let's define the variable and export it in 2 steps