### PR TITLE
vpnkit daemon: remove --log-destination

### DIFF
--- a/vpnkit/io.pixelfactory.vpnkit.plist
+++ b/vpnkit/io.pixelfactory.vpnkit.plist
@@ -27,8 +27,6 @@
       <string>192.168.66.3</string>
       <string>--highest-ip</string>
       <string>192.168.66.254</string>
-      <string>--log-destination</string>
-      <string>asl</string>
       <string>--gc-compact-interval</string>
       <string>1800</string>
     </array>


### PR DESCRIPTION
--log-destination has been removed in https://github.com/moby/vpnkit/pull/523/files
merge commit https://github.com/moby/vpnkit/commit/6123a2f4306ae4c5899e55b7b4985a317506982f

It crashes if this option is set.