### PR TITLE
Fix brew install command for multipass

### DIFF
--- a/hack/Makefile
+++ b/hack/Makefile
@@ -2,7 +2,7 @@ include ../global.mk
 hyperkit=/Library/Application\ Support/com.canonical.multipass/bin/hyperkit
 
 brew:
-	@$(BREW) cask reinstall multipass
+	@$(BREW) reinstall --cask multipass
 .PHONY: brew
 
 define install_hack


### PR DESCRIPTION
`brew cask ...` is no longer supported, changing to `brew reinstall --cask multipass`